### PR TITLE
Rename Duplicate to Redirected

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Discord bot built on Cloudflare Workers with the purpose of managing Q
 
 ## How it works
 
-The bot is triggered by a slash command `/questions` which takes a required `open` argument. The bot will then post a message in the questions channel, inviting users to submit questions via a button. When people submit a question, it gets posted to a separate questions channel via webhook, and the status of the question is clearly indicated (Answered, Unanswered, Duplicate, etc).
+The bot is triggered by a slash command `/questions` which takes a required `open` argument. The bot will then post a message in the questions channel, inviting users to submit questions via a button. When people submit a question, it gets posted to a separate questions channel via webhook, and the status of the question is clearly indicated (Answered, Unanswered, Redirected, etc).
 
 The status of these questions can be managed through Context Menus (right click on a question) and the bot will update the status of the question in the questions channel. For this case, anybody with Manage Messages permission can update the status of a question.
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import {
 	RouteBases,
 	Routes,
 } from "discord-api-types/v10";
-import { Unanswered, Answered, NeedsMoreInfo, Duplicate, FollowUp } from "./question-state";
+import { Unanswered, Answered, NeedsMoreInfo, Redirected, FollowUp } from "./question-state";
 import type { APIApplicationCommand } from "discord-api-types/v10";
 
 type ApplicationCommandCreate = Omit<APIApplicationCommand, "id" | "application_id" | "version">;
@@ -47,7 +47,7 @@ const commands: ApplicationCommandCreate[] = [
 		default_member_permissions: ManageMessages,
 	},
 	{
-		name: Duplicate.CmdName,
+		name: Redirected.CmdName,
 		description: "", // message commands don't have descriptions
 		type: ApplicationCommandType.Message,
 		default_member_permissions: ManageMessages,

--- a/src/question-state.ts
+++ b/src/question-state.ts
@@ -22,9 +22,9 @@ export const NeedsMoreInfo: QuestionState = {
 	Color: 0xefad67,
 };
 
-export const Duplicate: QuestionState = {
-	Title: "**🔁 Duplicate Question**",
-	CmdName: "Mark Duplicate",
+export const Redirected: QuestionState = {
+	Title: "**↪️ Question Redirected**",
+	CmdName: "Mark Redirected",
 	Color: 0xef6767,
 };
 
@@ -40,7 +40,7 @@ export function GetQuestionStateFromCommandName(commandName: string): QuestionSt
 			"Mark Answered": Answered,
 			"Mark Unanswered": Unanswered,
 			"Mark Needs More Info": NeedsMoreInfo,
-			"Mark Duplicate": Duplicate,
+			"Mark Redirected": Redirected,
 			"Mark as Will Follow Up": FollowUp,
 		}[commandName] || Unanswered
 	);


### PR DESCRIPTION
As discussed in Discord, rename the "Mark as duplicate" to "Mark as redirected". Since we are limited in the number of command actions, it's better to use a more general one here. This new marking can apply to questions in the wrong channel, not applicable to the Discord server, or duplicates (where they were redirected to the original question).