### PR TITLE
Remove Discriminators for Pomelo Users

### DIFF
--- a/src/handlers/modal-submit.ts
+++ b/src/handlers/modal-submit.ts
@@ -48,8 +48,9 @@ export default async function (
 					},
 				],
 				username:
-					interaction.member?.nick ??
-					`${interaction.member?.user.username}#${interaction.member.user.discriminator}`,
+					interaction.member?.nick ?? interaction.member?.user.discriminator === "0"
+						? `${interaction.member.user.username}#${interaction.member.user.discriminator}`
+						: interaction.member.user.username,
 				avatar_url: GetMemberAvatar(interaction.member, interaction.guild_id),
 			} as RESTPostAPIWebhookWithTokenJSONBody),
 		});


### PR DESCRIPTION
With the Pomelo update to Discord, most(if not all) users now don't have discriminators. The Discord API returns a Discriminator of `0` for these users, but showing this adds extra visual noise. This update removes the discriminator for any users that have already been Pomeloed.